### PR TITLE
Feature/login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "swiper": "^11.2.8",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",
-        "vue3-toastify": "^0.2.8"
+        "vue-toastification": "^2.0.0-rc.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -7750,6 +7750,14 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
+    },
+    "node_modules/vue-toastification": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
+      "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
+      "peerDependencies": {
+        "vue": "^3.0.2"
+      }
     },
     "node_modules/vue3-toastify": {
       "version": "0.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7759,24 +7759,6 @@
         "vue": "^3.0.2"
       }
     },
-    "node_modules/vue3-toastify": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/vue3-toastify/-/vue3-toastify-0.2.8.tgz",
-      "integrity": "sha512-8jDOqsJaBZEbGpCbhWDETJc11D1lZefvgFPq/IPdM+U7+qyXoVPDvK6uq/FIgyV7qV0NcNzvGBMEzjsLQqGROw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20",
-        "npm": ">=9.0.0"
-      },
-      "peerDependencies": {
-        "vue": ">=3.2.0"
-      },
-      "peerDependenciesMeta": {
-        "vue": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "swiper": "^11.2.8",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
-    "vue3-toastify": "^0.2.8"
+    "vue-toastification": "^2.0.0-rc.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,9 @@
 <script setup>
 import DefaultLayout from './layout/DefaultLayout.vue'
-
-import Vue3Toastify from 'vue3-toastify'
 </script>
+
 <template>
   <DefaultLayout>
     <RouterView />
-    <Vue3Toastify />
   </DefaultLayout>
 </template>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -14,32 +14,6 @@
   src: url('../assets//fonts//BagelFatOne.woff2') format('woff2');
 }
 
-/* 토스트 메세지 테두리용 css */
-.interestToastWrapper {
-  background-color: #7537e3 !important;
-  border-radius: 10px !important;
-  box-shadow: none !important;
-  border: none !important;
-}
-/* 토스트 메세지 내부용 css */
-.interestToast {
-  color: white;
-  font-weight: 700;
-  font-size: 20px;
-  padding: 12px;
-}
-
-/* 사용법
-toast() : 기본 일반 메시지
-toast.success() : 성공 메시지 (초록바)
-toast.error()
-toast.info() : 파란색
-tast.warning() : 경고 (주황색)
-
-위에 테두리용, 내부용을 각각 지정해줘야합니다. 다른 방법도 있는데 그건 검색해서 사용해주세요 (vue3-toastify 검색)
-npm vue3-toastify
-*/
-
 html,
 body,
 #app {

--- a/src/assets/toast-custom.css
+++ b/src/assets/toast-custom.css
@@ -1,0 +1,8 @@
+.Vue-Toastification__toast {
+  font-family: 'Pretendard', sans-serif;
+  font-size: 14px;
+  border-radius: 8px;
+  background: #191919;
+  color: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}

--- a/src/assets/toast-custom.css
+++ b/src/assets/toast-custom.css
@@ -5,4 +5,31 @@
   background: #191919;
   color: #fff;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  min-width: 160px;
+  max-width: 320px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px 32px !important;
 }
+
+.Vue-Toastification__icon {
+  display: none;
+}
+
+.Vue-Toastification__close-button {
+  color: #fff !important;
+  opacity: 0.8;
+  font-size: 16px !important;
+  top: 12px;
+  right: 18px;
+  margin-left: 10px;
+}
+
+/* .Vue-Toastification__container.top-center {
+  top: 24px !important;
+  bottom: auto !important;
+  left: 50% !important;
+  right: auto !important;
+  transform: translateX(-50%) !important;
+} */

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,10 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faHeart, faMessage } from '@fortawesome/free-regular-svg-icons'
 import { faMagnifyingGlass, faCaretDown } from '@fortawesome/free-solid-svg-icons'
+
+import Toast from 'vue-toastification'
+import '@/assets/toast-custom.css'
+
 library.add(faHeart, faMessage, faMagnifyingGlass, faCaretDown)
 
 const app = createApp(App)
@@ -18,5 +22,14 @@ app.component('font-awesome-icon', FontAwesomeIcon)
 
 app.use(createPinia())
 app.use(router)
+
+app.use(Toast, {
+  position: 'top-center',
+  timeout: 2000,
+  closeOnClick: true,
+  pauseOnHover: true,
+  hideProgressBar: true,
+  maxToasts: 1,
+})
 
 app.mount('#app')

--- a/src/main.js
+++ b/src/main.js
@@ -6,9 +6,6 @@ import '@/assets/root.css'
 import App from './App.vue'
 import router from './router'
 
-import Vue3Toastify from 'vue3-toastify'
-import 'vue3-toastify/dist/index.css'
-
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faHeart, faMessage } from '@fortawesome/free-regular-svg-icons'
@@ -16,11 +13,6 @@ import { faMagnifyingGlass, faCaretDown } from '@fortawesome/free-solid-svg-icon
 library.add(faHeart, faMessage, faMagnifyingGlass, faCaretDown)
 
 const app = createApp(App)
-
-app.use(Vue3Toastify, {
-  autoClose: 1000,
-  position: 'top-center',
-})
 
 app.component('font-awesome-icon', FontAwesomeIcon)
 

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,8 @@ import { faHeart, faMessage } from '@fortawesome/free-regular-svg-icons'
 import { faMagnifyingGlass, faCaretDown } from '@fortawesome/free-solid-svg-icons'
 
 import Toast from 'vue-toastification'
-import '@/assets/toast-custom.css'
+// import '@/assets/toast-custom.css'
+import 'vue-toastification/dist/index.css'
 
 library.add(faHeart, faMessage, faMagnifyingGlass, faCaretDown)
 

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -77,7 +77,7 @@ function onLogin() {
               v-model="password"
               placeholder=""
               required
-              class="peer w-[360px] h-[61px] text-[16px] rounded-[12px] px-4 py-2 pt-6 focus:outline-none border dark:border-[#4D4D4D]"
+              class="peer w-[360px] h-[61px] text-[16px] rounded-[12px] px-4 py-2 pt-6 focus:outline-none border border-[#DFDFDF] dark:border-[#4D4D4D]"
             />
             <label
               class="absolute left-[16px] top-[12px] text-[#BDBDBD] text-[12px] transition-all duration-200 pointer-events-none origin-[0] peer-focus:top-[12px] peer-focus:text-[12px] peer-placeholder-shown:text-[16px] peer-placeholder-shown:top-[20px]"

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,6 +1,10 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { useThemeStore } from '@/stores/useDarkmode'
+import supabase from '@/utils/supabase'
+import { useToast } from 'vue-toastification'
+import { useRouter } from 'vue-router'
+import router from '@/router'
 
 const { toggleDark } = useThemeStore()
 
@@ -11,13 +15,31 @@ const isEmailValid = ref(true)
 
 const isLoginDisabled = computed(() => !(email.value && password.value))
 
+const toast = useToast()
+
 function validateEmail() {
   const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
   isEmailValid.value = emailPattern.test(email.value)
 }
 
-function onLogin() {
-  // 로그인 처리 로직 추가
+async function onLogin() {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: email.value,
+    password: password.value,
+  })
+
+  if (error) {
+    if (error.message.includes('Invalid login credentials')) {
+      toast('이메일 또는 비밀번호가 올바르지 않습니다.')
+    } else if (error.message.includes('Email not confirmed')) {
+      toast('이메일 인증이 완료되지 않았습니다. 메일을 확인하세요.')
+    } else {
+      toast('로그인에 실패했습니다.', { icon: false })
+    }
+    return
+  }
+
+  router.push('/')
 }
 </script>
 <template>

--- a/src/views/SignUpView.vue
+++ b/src/views/SignUpView.vue
@@ -58,6 +58,8 @@ async function validateNickName() {
     nicknameError.value = '닉네임을 입력해주세요.'
   } else if (!nicknamePattern.test(nickname.value)) {
     nicknameError.value = '특수문자, 공백 제외 2~8글자로 입력해주세요.'
+  } else if (/^\d+$/.test(nickname.value)) {
+    nicknameError.value = '영문이나 한글을 포함해 주세요.'
   } else {
     nicknameError.value = ''
   }

--- a/src/views/SignUpView.vue
+++ b/src/views/SignUpView.vue
@@ -4,7 +4,10 @@ import { useThemeStore } from '@/stores/useDarkmode'
 import supabase from '@/utils/supabase'
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { toast } from 'vue3-toastify'
+
+//토스트 메시지 팝업
+import { useToast } from 'vue-toastification'
+const toast = useToast()
 
 const email = ref('')
 const name = ref('')
@@ -12,12 +15,15 @@ const nickname = ref('')
 const password = ref('')
 const passwordCheck = ref('')
 
-const errorMsg = ref('')
 const nicknameError = ref('')
 const emailError = ref('')
 const nameError = ref('')
 const passwordError = ref('')
 const passwordCheckError = ref('')
+
+//중복 체크 결과
+const isEmailAvailable = ref(false)
+const isNicknameAvailable = ref(false)
 
 const router = useRouter()
 const authStore = userAuthStore()
@@ -46,7 +52,7 @@ function validateName() {
   }
 }
 
-function validateNickName() {
+async function validateNickName() {
   const nicknamePattern = /^[A-Za-z0-9가-힣]{2,8}$/
   if (!nickname.value) {
     nicknameError.value = '닉네임을 입력해주세요.'
@@ -78,7 +84,43 @@ function validatePasswordCheck() {
   }
 }
 
-//input 값 변경시 검증 실행
+//이메일 중복 확인
+async function checkEmailDuplicate() {
+  validateEmail()
+  if (emailError.value) return
+  const { data } = await supabase
+    .from('profiles')
+    .select('email')
+    .eq('email', email.value)
+    .maybeSingle()
+  if (data) {
+    emailError.value = '이미 등록된 이메일입니다.'
+    isEmailAvailable.value = false
+  } else {
+    emailError.value = ''
+    isEmailAvailable.value = true
+  }
+}
+
+//닉네임 중복 확인
+async function checkNicknameDuplicate() {
+  validateNickName()
+  if (nicknameError.value) return
+  const { data } = await supabase
+    .from('profiles')
+    .select('nickname')
+    .eq('nickname', nickname.value)
+    .maybeSingle()
+  if (data) {
+    nicknameError.value = '이미 등록된 닉네임입니다.'
+    isNicknameAvailable.value = false
+  } else {
+    nicknameError.value = ''
+    isNicknameAvailable.value = true
+  }
+}
+
+//input값 변경시 검증 실행
 watch(email, () => validateEmail())
 watch(name, () => validateName())
 watch(nickname, () => validateNickName())
@@ -87,22 +129,26 @@ watch(passwordCheck, () => validatePasswordCheck())
 
 //회원 가입 post - superbase연동
 async function onSignUp() {
+  //제출 전 검증
   validateEmail()
   validateName()
   validateNickName()
   validatePassword()
   validatePasswordCheck()
 
+  // 중복 체크 상태 확인
   if (
-    emailError.value ||
+    !isEmailAvailable.value ||
+    !isNicknameAvailable.value ||
     nameError.value ||
-    nicknameError.value ||
     passwordError.value ||
     passwordCheckError.value
   ) {
+    toast.error('문제가 발생하였습니다.')
     return
   }
 
+  // Supabase 회원가입
   const { data, error } = await supabase.auth.signUp({
     email: email.value,
     password: password.value,
@@ -115,19 +161,23 @@ async function onSignUp() {
   })
 
   if (error) {
-    errorMsg.value = error.message
+    toast.error('회원가입에 문제가 발생했습니다: ' + error.message)
     return
   }
-  toast.success('회원가입이 완료되었습니다. 이메일을 확인해주세요.')
-  router.push('/login')
+
+  authStore.setUser(data.user)
+  toast('회원가입이 완료되었습니다. 이메일을 확인해주세요!')
+  setTimeout(() => {
+    router.push('/login')
+  }, 1200)
 }
 
 //회원가입 버튼 비활성화
 const isDisabled = computed(
   () =>
-    emailError.value ||
+    !isEmailAvailable.value ||
+    !isNicknameAvailable.value ||
     nameError.value ||
-    nicknameError.value ||
     passwordError.value ||
     passwordCheckError.value ||
     !email.value ||
@@ -172,11 +222,16 @@ const isDisabled = computed(
                 required
                 :class="[
                   'w-[364px] h-[50px] text-[16px] border rounded-[8px] px-3 py-2 focus:outline-none dark:text-white',
-                  emailError ? 'border-[#F34040] ' : 'border-[#DFDFDF] dark:border-[#4D4D4D]',
+                  emailError
+                    ? 'border-[#F34040]'
+                    : isEmailAvailable
+                      ? 'border-[#00D62B]'
+                      : 'border-[#DFDFDF] dark:border-[#4D4D4D]',
                 ]"
               />
               <button
                 type="button"
+                @click="checkEmailDuplicate"
                 class="w-[51px] h-[28px] text-[#7537e3] text-[13px] rounded-[6px] border font-medium border-[#7537e3] absolute top-1/2 -translate-y-1/2 right-[10px] cursor-pointer dark:text-[#B185FF] dark:border-[#B185FF] dark:hover:border-[#6524D9] dark:hover:bg-[#6524D9] hover:dark:text-white transition-all duration-300"
               >
                 확인
@@ -184,6 +239,12 @@ const isDisabled = computed(
             </div>
             <p v-if="emailError" class="text-[#F34040] text-[11px] mt-[6px] ml-1 leading-[1.5]">
               {{ emailError }}
+            </p>
+            <p
+              v-else-if="isEmailAvailable"
+              class="text-[#00D62B] text-[11px] mt-[6px] ml-1 leading-[1.5]"
+            >
+              사용 가능한 이메일입니다.
             </p>
           </div>
         </div>
@@ -222,11 +283,16 @@ const isDisabled = computed(
                 required
                 :class="[
                   'w-[364px] h-[50px] text-[16px] border rounded-[8px] px-3 py-2 focus:outline-none dark:text-white',
-                  nicknameError ? 'border-[#F34040] ' : 'border-[#DFDFDF] dark:border-[#4D4D4D]',
+                  nicknameError
+                    ? 'border-[#F34040]'
+                    : isNicknameAvailable
+                      ? 'border-[#00D62B]'
+                      : 'border-[#DFDFDF] dark:border-[#4D4D4D]',
                 ]"
               />
               <button
                 type="button"
+                @click="checkNicknameDuplicate"
                 class="w-[51px] h-[28px] text-[#7537e3] text-[13px] rounded-[6px] border font-medium border-[#7537e3] absolute top-1/2 -translate-y-1/2 right-[10px] cursor-pointer dark:text-[#B185FF] dark:border-[#B185FF] dark:hover:border-[#6524D9] dark:hover:bg-[#6524D9] hover:dark:text-white transition-all duration-300"
               >
                 확인
@@ -234,6 +300,12 @@ const isDisabled = computed(
             </div>
             <p v-if="nicknameError" class="text-[#F34040] text-[11px] mt-[6px] ml-1 leading-[1.5]">
               {{ nicknameError }}
+            </p>
+            <p
+              v-else-if="isNicknameAvailable"
+              class="text-[#00D62B] text-[11px] mt-[6px] ml-1 leading-[1.5]"
+            >
+              사용 가능한 닉네임입니다.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## ✨ PR 개요

---

## 🛠️ 작업 상세 내용

이번 PR에서 수행한 작업 유형에 체크해 주세요.

- [x] New Feature (새 기능 추가)
- [ ] Bug Fix (버그 수정)
- [ ] Remove Feature (기능 제거)
- [ ] Change Logic (로직 수정)
- [x] Style (스타일 수정: 코드 포맷, CSS 등)
- [ ] Test (테스트 코드 추가/수정)
- [ ] Set up (환경 설정, 패키지 설정 등)

---

## 🔥 작업 내용 및 관련 이슈

- 로그인 및 회원가입 로직 구현하였습니다.
- superbase auth가 살짝 복잡하여 내일 스크럼 시간에 간략히 설명드리겠습니다.
(토큰 폐기나 재발급은 아직 미구현입니다.)
- 닉네임 및 이메일 중복 확인 기능 로직을 수정하였습니다.
- 닉네임/이메일 중복 확인을 누르지 않으면 회원가입 button 이 disabled 됨으로 처리합니다.
- 토스트 이벤트 조건
회원가입 완료 시/이메일 인증을 하지 않은 채로 로그인/로그인 실패(이메일이나 비밀번호 오류)


---

## 📜 새로 설치한 패키지 목록

- 토스트 메시지 라이브러리 변경 toastify -> toastification
- DOCS : https://github.com/Maronato/vue-toastification
- Test : https://vue-toastification.maronato.dev/
(git pull 받고 npm i )

---

## 📸 스크린샷 (선택)

라이트 모드일 때, 
<img width="489" alt="스크린샷 2025-06-09 오후 9 17 26" src="https://github.com/user-attachments/assets/97174193-8a96-4f5d-8aa3-4fa6c63f4fbf" />

다크 모드일 때,
<img width="507" alt="스크린샷 2025-06-09 오후 9 17 52" src="https://github.com/user-attachments/assets/d082c8a3-2992-4181-8a4e-ea74210b3305" />

회원 가입 완료 후 토스트 메시지 나타난 후 메인으로 라우트 됨(임시)
<img width="430" alt="스크린샷 2025-06-09 오후 10 48 28" src="https://github.com/user-attachments/assets/068d0413-9e9a-4ae1-9dd4-6689203e3be5" />



이메일 인증을 하지않고 로그인 할 시,
<img width="454" alt="스크린샷 2025-06-09 오후 10 41 51" src="https://github.com/user-attachments/assets/8b5b2771-01b9-4994-b4da-435aa63353e4" />


로그인 성공 시 토큰은 supabase-js가 자동으로 localStorage에 저장
<img width="673" alt="스크린샷 2025-06-09 오후 9 16 10" src="https://github.com/user-attachments/assets/c55cba55-a207-4411-9b89-595126bc7e1b" />


---

## ✍️ 리뷰 시 참고 사항
- 관심사 선택 페이지 퍼블리싱 완료되면 회원가입 후 바로 관심사 선택 페이지로 라우트 될 예정입니다.
- 헤더에 로그아웃 버튼이 있어야 할 것 같습니다.
- 토스트 메시지 커스텀 css에 스타일링이 안먹는 이슈가 있어서 일단 디폴트 스타일링으로 구현하였습니다.
- (src/assets/toast-custom.css 에 주석처리 해놨습니다)
