### PR TITLE
🚑 hotfix : pinia 연동 동기화

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,8 @@ import router from './router'
 import Toast from 'vue-toastification'
 // import '@/assets/toast-custom.css'
 import 'vue-toastification/dist/index.css'
+import supabase from './utils/supabase'
+import { userAuthStore } from './stores/authStore'
 
 const app = createApp(App)
 
@@ -22,6 +24,16 @@ app.use(Toast, {
   pauseOnHover: true,
   hideProgressBar: true,
   maxToasts: 1,
+})
+
+//토큰 상태 변화 감지 -> 피니아 반영
+supabase.auth.onAuthStateChange(async (event, session) => {
+  const authStore = userAuthStore()
+  if (session?.user) {
+    await authStore.fetchUser()
+  } else {
+    authStore.logout()
+  }
 })
 
 app.mount('#app')


### PR DESCRIPTION
## ✨ PR 개요

---

## 🛠️ 작업 상세 내용

피니아 연동을 앱 전체에서 한 번만 실행하고, 인증 상태가 바뀔 때만 동기화 되도록 수정하였습니다.

이메일 인증에서 confirm 을 눌렀을 때 url 에서 나오는 에러로 인해 인증이 안되던 현상을 고쳤습니다.
이메일 프로세스 중에 auth -> profiles 정의 트리거 함수로 인해 인증 상태가 중복 정의되어 오류가 발생하는 것을 찾았습니다.
트리거를 사용하지 않고 supabase.auth 로만 인증 상태를 관리해서 auth 테이블에만 의존하도록 변경하였습니다.

이번 PR에서 수행한 작업 유형에 체크해 주세요.

- [ ] New Feature (새 기능 추가)
- [x] Bug Fix (버그 수정)
- [ ] Remove Feature (기능 제거)
- [ ] Change Logic (로직 수정)
- [ ] Style (스타일 수정: 코드 포맷, CSS 등)
- [ ] Test (테스트 코드 추가/수정)
- [ ] Set up (환경 설정, 패키지 설정 등)


