### PR TITLE
✨ feat : sb에 저장할 때, 카테고리 맵핑해서 저장

### DIFF
--- a/src/composables/newsCache.js
+++ b/src/composables/newsCache.js
@@ -2,8 +2,29 @@
 import dayjs from 'dayjs'
 import supabase from '@/utils/supabase'
 import { fetchNewsData } from '@/api/fetchNews'
+import { categoryIdMap } from '@/composables/useCategoryMap'
 
 const NEWS_TTL_MINUTES = 10
+const getCategoryIdFromName = (categoryArrStr) => {
+  let engKey = null
+  try {
+    if (!categoryArrStr) return null
+    // 배열 문자열이면 파싱
+    if (typeof categoryArrStr === 'string' && categoryArrStr.startsWith('[')) {
+      const arr = JSON.parse(categoryArrStr)
+      if (Array.isArray(arr) && arr.length > 0) {
+        engKey = arr[0].toLowerCase()
+      }
+    } else if (typeof categoryArrStr === 'string') {
+      engKey = categoryArrStr.toLowerCase()
+    }
+    const id = categoryIdMap[engKey] ?? null
+    console.log('[카테고리 매핑] 원본:', categoryArrStr, '| 추출:', engKey, '| 매핑된 ID:', id)
+    return categoryIdMap[engKey] ?? null
+  } catch {
+    return null
+  }
+}
 
 export async function getFreshNews(keywords, language) {
   const { data: newsArr } = await supabase
@@ -25,18 +46,30 @@ export async function getFreshNews(keywords, language) {
     const freshNews = await fetchNewsData(keywords, language)
     if (freshNews && freshNews.length > 0) {
       await supabase.from('news').upsert(
-        freshNews.map((news) => ({
-          news_id: news.article_id,
-          category_id: news.category_id ?? null,
-          title: news.title,
-          link: news.link,
-          keywords: news.keywords ?? [],
-          description: news.description,
-          pub_date: news.pub_date ?? null,
-          image_url: news.image_url,
-          source_name: news.source_name,
-          category: news.category,
-        })),
+        freshNews.map((news) => {
+          const mappedId = getCategoryIdFromName(news.category)
+          // 디버깅: 각 뉴스별 매핑 결과
+          console.log(
+            '[뉴스 저장] news.article_id:',
+            news.article_id,
+            '| category:',
+            news.category,
+            '| category_id:',
+            mappedId,
+          )
+          return {
+            news_id: news.article_id,
+            category_id: mappedId,
+            title: news.title,
+            link: news.link,
+            keywords: news.keywords ?? [],
+            description: news.description,
+            pub_date: news.pub_date ?? null,
+            image_url: news.image_url,
+            source_name: news.source_name,
+            category: news.category,
+          }
+        }),
       )
     }
     return freshNews

--- a/src/composables/useCategoryMap.js
+++ b/src/composables/useCategoryMap.js
@@ -1,0 +1,32 @@
+// utils/categoryMap.js
+export const categoryNameMap = {
+  politics: '정치',
+  sports: '스포츠',
+  business: '경제',
+  entertainment: '연예',
+  entertain: '연예',
+  culture: '문화',
+  abroad: '해외',
+  world: '해외',
+  society: '사회',
+  economy: '경제',
+  technology: '기술',
+  top: '사회',
+  other: '그 외',
+  etc: '그 외',
+}
+
+export const categoryIdMap = {
+  politics: 1, // 정치
+  sports: 2, // 스포츠
+  entertainment: 3, // 연예
+  entertain: 3, // 연예 (동의어)
+  culture: 4, // 문화
+  abroad: 5, // 해외
+  world: 5, // 해외 (동의어)
+  society: 6, // 사회
+  economy: 7, // 경제
+  business: 7, // 경제 (동의어)
+  etc: 8, // 그 외
+  other: 8, // 그 외 (동의어)
+}

--- a/src/composables/useCategoryMap.js
+++ b/src/composables/useCategoryMap.js
@@ -1,4 +1,3 @@
-// utils/categoryMap.js
 export const categoryNameMap = {
   politics: '정치',
   sports: '스포츠',

--- a/src/composables/useInterestMap.js
+++ b/src/composables/useInterestMap.js
@@ -1,0 +1,20 @@
+// constants/interests.ts
+import politicsIcon from '@/assets/icons/politics.svg'
+import sportsIcon from '@/assets/icons/sports.svg'
+import entertainmentIcon from '@/assets/icons/entertainment.svg'
+import cultureIcon from '@/assets/icons/culture.svg'
+import worldIcon from '@/assets/icons/world.svg'
+import societyIcon from '@/assets/icons/society.svg'
+import economyIcon from '@/assets/icons/economy.svg'
+import etcIcon from '@/assets/icons/etc.svg'
+
+export const interestMap = [
+  { id: 'politics', label: '정치', icon: politicsIcon },
+  { id: 'sports', label: '스포츠', icon: sportsIcon },
+  { id: 'entertain', label: '연예', icon: entertainmentIcon },
+  { id: 'culture', label: '문화', icon: cultureIcon },
+  { id: 'abroad', label: '해외', icon: worldIcon },
+  { id: 'society', label: '사회', icon: societyIcon },
+  { id: 'economy', label: '경제', icon: economyIcon },
+  { id: 'etc', label: '그 외', icon: etcIcon },
+]

--- a/src/composables/useNewsActions.js
+++ b/src/composables/useNewsActions.js
@@ -1,36 +1,12 @@
 import { useNewsStore } from '@/stores/newsStore'
 import supabase from '@/utils/supabase'
 import { useRouter } from 'vue-router'
+import { categoryIdMap } from './useCategoryMap'
+import { interestMap } from '@/composables/useInterestMap'
+const interests = interestMap.map(({ id, label }) => ({ id, label }))
 
 // news component에서 사용할 함수들을 지정
 export const useNewsActions = () => {
-  const interests = [
-    { id: 'politics', label: '정치' },
-    { id: 'sports', label: '스포츠' },
-    { id: 'entertain', label: '연예' },
-    { id: 'entertainment', label: '연예' },
-    { id: 'culture', label: '문화' },
-    { id: 'abroad', label: '해외' },
-    { id: 'world', label: '해외' },
-    { id: 'society', label: '사회' },
-    { id: 'economy', label: '경제' },
-    { id: 'business', label: '경제' },
-    { id: 'etc', label: '그 외' },
-  ]
-  const categoryIdMap = {
-    politics: 1, // 정치
-    sports: 2, // 스포츠
-    entertainment: 3, // 연예
-    entertain: 3,
-    culture: 4, // 문화
-    abroad: 5, // 해외
-    world: 5,
-    society: 6, // 사회
-    economy: 7, // 경제
-    business: 7,
-    etc: 8, // 그 외
-  }
-
   const router = useRouter()
   const newsStore = useNewsStore()
   newsStore.selectedNews

--- a/src/views/ChooseInterest.vue
+++ b/src/views/ChooseInterest.vue
@@ -3,30 +3,13 @@ import InterestCard from '@/components/interest/InterestCard.vue'
 import { useInterestStore } from '@/stores/interestStore'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-
-import politicsIcon from '@/assets/icons/politicsIcon.svg'
-import sportsIcon from '@/assets/icons/sportsIcon.svg'
-import entertainmentIcon from '@/assets/icons/entertainmentIcon.svg'
-import cultureIcon from '@/assets/icons/cultureIcon.svg'
-import worldIcon from '@/assets/icons/worldIcon.svg'
-import societyIcon from '@/assets/icons/societyIcon.svg'
-import economyIcon from '@/assets/icons/economyIcon.svg'
-import etcIcon from '@/assets/icons/etcIcon.svg'
 import { userAuthStore } from '@/stores/authStore'
+import { interestMap } from '@/composables/useInterestMap'
 
 const store = useInterestStore()
 const auth = userAuthStore()
 const name = ref(auth.user?.name || '사용자')
-const interests = [
-  { id: 'politics', label: '정치', icon: politicsIcon },
-  { id: 'sports', label: '스포츠', icon: sportsIcon },
-  { id: 'entertain', label: '연예', icon: entertainmentIcon },
-  { id: 'culture', label: '문화', icon: cultureIcon },
-  { id: 'abroad', label: '해외', icon: worldIcon },
-  { id: 'society', label: '사회', icon: societyIcon },
-  { id: 'economy', label: '경제', icon: economyIcon },
-  { id: 'etc', label: '그 외', icon: etcIcon },
-]
+const interests = interestMap
 
 //관심사 추가
 const addInterest = (item) => {


### PR DESCRIPTION
## 🛠️ 작업 상세 내용

- [x] New Feature (새 기능 추가)
- [ ] Bug Fix (버그 수정)
- [ ] Remove Feature (기능 제거)
- [ ] Change Logic (로직 수정)
- [ ] Style (스타일 수정: 코드 포맷, CSS 등)
- [ ] Test (테스트 코드 추가/수정)
- [ ] Set up (환경 설정, 패키지 설정 등)

---

## 🔥 작업 내용 및 관련 이슈

카테고리 맵핑 함수 src\composables\useCategoryMap.js 추가
1.  영문이름 - 한글이름 (categoryNameMap)
2. 영문이름 - 카테고리 id (categoryIdMap)

추가하였습니다. 맵핑하실 일 있으면 여기서 사용해주시면 됩니다.

sb에서 저장할 때 category_id를 맵핑해서 넘기는 로직을 추가하였습니다.
